### PR TITLE
Reference migration. New PR 

### DIFF
--- a/Lottie.iOS/Lottie.iOS.csproj
+++ b/Lottie.iOS/Lottie.iOS.csproj
@@ -25,7 +25,6 @@
 
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
     <ObjcBindingApiDefinition Include="ApiDefinitions.Ios.cs" />
-    <ObjcBindingNativeLibrary Include="libLottie-ios.a" />
     <Compile Include="libLottie-ios.linkwith.cs">
       <DependentUpon>libLottie-ios.a</DependentUpon>
     </Compile>
@@ -33,7 +32,6 @@
 
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
     <ObjcBindingApiDefinition Include="ApiDefinitions.Mac.cs" />
-    <ObjcBindingNativeLibrary Include="libLottie-macos.a" />
     <Compile Include="libLottie-macos.linkwith.cs">
       <DependentUpon>libLottie-macos.a</DependentUpon>
     </Compile>
@@ -41,7 +39,6 @@
 
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tvos'">
     <ObjcBindingApiDefinition Include="ApiDefinitions.Ios.cs" />
-    <ObjcBindingNativeLibrary Include="libLottie-tvos.a" />
     <Compile Include="libLottie-tvos.linkwith.cs">
       <DependentUpon>libLottie-tvos.a</DependentUpon>
     </Compile>
@@ -50,4 +47,19 @@
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'watchos'">
   </ItemGroup>
 
+  <ItemGroup>
+    <NativeReference Include="..\Lottie.iOS\libLottie-ios.a">
+      <Kind>Static</Kind>
+      <SmartLink>true</SmartLink>
+    </NativeReference>
+    <NativeReference Include="..\Lottie.iOS\libLottie-macos.a">
+      <Kind>Static</Kind>
+      <SmartLink>true</SmartLink>
+    </NativeReference>
+    <NativeReference Include="..\Lottie.iOS\libLottie-tvos.a">
+      <Kind>Static</Kind>
+      <SmartLink>true</SmartLink>
+    </NativeReference>
+  </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
✨ What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Adds a binder library for migrating iOS to NativeReferences. This is needed to be able to build a nuget from the iOS project.

⤵️ What is the current behavior?
Doesn't change any behaviour.

🆕 What is the new behavior (if this is a feature change)?
Doesn't change any behaviour.

💥 Does this PR introduce a breaking change?
Shouldn't

🐛 Recommendations for testing
Build nuget from migrated iOS project.

📝 Links to relevant issues/docs
https://learn.microsoft.com/en-us/dotnet/maui/migration/ios-binding-projects?view=net-maui-8.0

🤔 Checklist before submitting
 All projects build
 Follows style guide lines
 Relevant documentation was updated
 Rebased onto current develop